### PR TITLE
Add null_safe and typed functions

### DIFF
--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -23,4 +23,5 @@ strategies.tools      - some conglomerate strategies that do depend on SymPy
 """
 
 from .core import condition, debug, chain, do_one, exhaust, minimize
+from .tools import typed
 from . import branch

--- a/strategies/core.py
+++ b/strategies/core.py
@@ -49,6 +49,17 @@ def debug(fn, file=None):
     return onaction(fn, write)
 
 
+def null_safe(rule):
+    """ Return original expr if rule returns None """
+    def null_safe_rl(expr):
+        result = rule(expr)
+        if result is None:
+            return expr
+        else:
+            return result
+    return null_safe_rl
+
+
 @curry
 def do_one(fns, x):
     """ Try each of the functions until one works. Then stop. """

--- a/strategies/tests/test_core.py
+++ b/strategies/tests/test_core.py
@@ -1,6 +1,17 @@
 from strategies.core import (exhaust, memoize, condition,
-        chain, do_one, debug, switch, minimize)
+        chain, do_one, debug, switch, minimize, null_safe)
 from functools import partial
+
+
+def test_null_safe():
+    def rl(expr):
+        if expr == 1:
+            return 2
+    safe_rl = null_safe(rl)
+    assert rl(1) == safe_rl(1)
+
+    assert      rl(3) == None
+    assert safe_rl(3) == 3
 
 def posdec(x):
     if x > 0:

--- a/strategies/tools.py
+++ b/strategies/tools.py
@@ -1,0 +1,12 @@
+from __future__ import print_function, division
+
+from .core import do_one, exhaust, switch
+
+
+def typed(ruletypes):
+    """Apply rules based on the expression type
+
+    inputs:
+        ruletypes -- a dict mapping {Type: rule}
+    """
+    return switch(type, ruletypes)


### PR DESCRIPTION
fixes #3

All other functions (i.e. new, unpack, etc, see full list below) looks to be sympy-specific:
```
$ git grep 'sympy.strategies.*import'
sympy/matrices/expressions/blockmatrix.py:from sympy.strategies import unpack
sympy/matrices/expressions/hadamard.py:from sympy.strategies import unpack, flatten
sympy/matrices/expressions/matadd.py:from sympy.strategies import rm_id, unpack, flatten, sort, glom
sympy/matrices/expressions/matmul.py:from sympy.strategies import rm_id, unpack, flatten, new
```